### PR TITLE
Terminal dark theme, paginacja, banner cookies

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,9 +3,7 @@ title: Mateusz Grotha
 email: matgrotha@gmail.com
 description: > # this means to ignore newlines until "baseurl:"
   developer, ruby, DIY, linux, martial arts
-remote_theme: pages-themes/merlot@v0.2.0
-plugins:
-- jekyll-remote-theme
+
 baseurl: "" # the subpath of your site, e.g. /blog/
 url: "https://biscoitinho.github.io"
 twitter_username:

--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,9 @@ email: matgrotha@gmail.com
 description: > # this means to ignore newlines until "baseurl:"
   developer, ruby, DIY, linux, martial arts
 
+paginate: 10
+paginate_path: "/page:num/"
+
 baseurl: "" # the subpath of your site, e.g. /blog/
 url: "https://biscoitinho.github.io"
 twitter_username:
@@ -11,3 +14,5 @@ github_username:  biscoitinho
 
 # Build settings
 markdown: kramdown
+plugins:
+  - jekyll-paginate

--- a/_includes/cookie-consent.html
+++ b/_includes/cookie-consent.html
@@ -1,0 +1,28 @@
+<div class="cookie-banner" id="cookieBanner">
+  <div class="cookie-inner">
+    <span class="cookie-msg">
+      <span class="cookie-prompt">$</span> cookies.sh:
+      ta strona używa plików cookie do analizy ruchu i podstawowych funkcji.
+      <a href="https://policies.google.com/privacy" target="_blank" rel="noopener">więcej info</a>
+    </span>
+    <div class="cookie-actions">
+      <button class="cookie-btn cookie-accept" onclick="cookieConsent(true)">[ akceptuję ]</button>
+      <button class="cookie-btn cookie-decline" onclick="cookieConsent(false)">[ odrzucam ]</button>
+    </div>
+  </div>
+</div>
+
+<script>
+  (function() {
+    if (localStorage.getItem('cookie-consent') !== null) {
+      document.getElementById('cookieBanner').style.display = 'none';
+    }
+  })();
+
+  function cookieConsent(accepted) {
+    localStorage.setItem('cookie-consent', accepted ? 'accepted' : 'declined');
+    var banner = document.getElementById('cookieBanner');
+    banner.style.opacity = '0';
+    setTimeout(function() { banner.style.display = 'none'; }, 300);
+  }
+</script>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,55 +1,15 @@
 <footer class="site-footer">
-
   <div class="wrapper">
-
-    <h2 class="footer-heading">{{ site.title }}</h2>
-
-    <div class="footer-col-wrapper">
-      <div class="footer-col  footer-col-1">
-        <ul class="contact-list">
-          <li>{{ site.title }}</li>
-          <li><a href="mailto:{{ site.email }}">{{ site.email }}</a></li>
-        </ul>
-      </div>
-
-      <div class="footer-col  footer-col-2">
-        <ul class="social-media-list">
-          {% if site.github_username %}
-          <li>
-            <a href="https://github.com/{{ site.github_username }}">
-              <span class="icon  icon--github">
-                <svg viewBox="0 0 16 16">
-                  <path fill="#828282" d="M7.999,0.431c-4.285,0-7.76,3.474-7.76,7.761 c0,3.428,2.223,6.337,5.307,7.363c0.388,0.071,0.53-0.168,0.53-0.374c0-0.184-0.007-0.672-0.01-1.32 c-2.159,0.469-2.614-1.04-2.614-1.04c-0.353-0.896-0.862-1.135-0.862-1.135c-0.705-0.481,0.053-0.472,0.053-0.472 c0.779,0.055,1.189,0.8,1.189,0.8c0.692,1.186,1.816,0.843,2.258,0.645c0.071-0.502,0.271-0.843,0.493-1.037 C4.86,11.425,3.049,10.76,3.049,7.786c0-0.847,0.302-1.54,0.799-2.082C3.768,5.507,3.501,4.718,3.924,3.65 c0,0,0.652-0.209,2.134,0.796C6.677,4.273,7.34,4.187,8,4.184c0.659,0.003,1.323,0.089,1.943,0.261 c1.482-1.004,2.132-0.796,2.132-0.796c0.423,1.068,0.157,1.857,0.077,2.054c0.497,0.542,0.798,1.235,0.798,2.082 c0,2.981-1.814,3.637-3.543,3.829c0.279,0.24,0.527,0.713,0.527,1.437c0,1.037-0.01,1.874-0.01,2.129 c0,0.208,0.14,0.449,0.534,0.373c3.081-1.028,5.302-3.935,5.302-7.362C15.76,3.906,12.285,0.431,7.999,0.431z"/>
-                </svg>
-              </span>
-
-              <span class="username">{{ site.github_username }}</span>
-            </a>
-          </li>
-          {% endif %}
-
-          {% if site.twitter_username %}
-          <li>
-            <a href="https://twitter.com/{{ site.twitter_username }}">
-              <span class="icon  icon--twitter">
-                <svg viewBox="0 0 16 16">
-                  <path fill="#828282" d="M15.969,3.058c-0.586,0.26-1.217,0.436-1.878,0.515c0.675-0.405,1.194-1.045,1.438-1.809
-                  c-0.632,0.375-1.332,0.647-2.076,0.793c-0.596-0.636-1.446-1.033-2.387-1.033c-1.806,0-3.27,1.464-3.27,3.27 c0,0.256,0.029,0.506,0.085,0.745C5.163,5.404,2.753,4.102,1.14,2.124C0.859,2.607,0.698,3.168,0.698,3.767 c0,1.134,0.577,2.135,1.455,2.722C1.616,6.472,1.112,6.325,0.671,6.08c0,0.014,0,0.027,0,0.041c0,1.584,1.127,2.906,2.623,3.206 C3.02,9.402,2.731,9.442,2.433,9.442c-0.211,0-0.416-0.021-0.615-0.059c0.416,1.299,1.624,2.245,3.055,2.271 c-1.119,0.877-2.529,1.4-4.061,1.4c-0.264,0-0.524-0.015-0.78-0.046c1.447,0.928,3.166,1.469,5.013,1.469 c6.015,0,9.304-4.983,9.304-9.304c0-0.142-0.003-0.283-0.009-0.423C14.976,4.29,15.531,3.714,15.969,3.058z"/>
-                </svg>
-              </span>
-
-              <span class="username">{{ site.twitter_username }}</span>
-            </a>
-          </li>
-          {% endif %}
-        </ul>
-      </div>
-
-      <div class="footer-col  footer-col-3">
-        <p class="text">made with ruby, jekyll, scss and passion for programming and minimalistic designs</p>
-      </div>
+    <div class="footer-inner">
+      <span class="footer-prompt"><span class="prompt-dollar">$</span> exit 0</span>
+      <span class="footer-links">
+        {% if site.github_username %}
+        <a href="https://github.com/{{ site.github_username }}">gh/{{ site.github_username }}</a>
+        {% endif %}
+        {% if site.email %}
+        <a href="mailto:{{ site.email }}">{{ site.email }}</a>
+        {% endif %}
+      </span>
     </div>
-
   </div>
-
 </footer>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,5 +9,7 @@
   <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" />
-  <link href='http://fonts.googleapis.com/css?family=Open+Sans:300&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500&display=swap" rel="stylesheet">
 </head>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,5 +11,5 @@
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@300;400;500&display=swap" rel="stylesheet">
 </head>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,24 +1,24 @@
 <header class="site-header">
   <div class="wrapper">
-    <a class="site-title" href="{{ site.baseurl }}/">{{ site.title }}</a>
+    <a class="site-title" href="{{ site.baseurl }}/">
+      <span class="prompt-user">{{ site.github_username }}</span><span class="prompt-at">@</span><span class="prompt-host">github</span><span class="prompt-sep">:</span><span class="prompt-path">~</span><span class="prompt-dollar"> $</span>
+    </a>
     <nav class="site-nav">
       <a href="#" class="menu-icon">
         <svg viewBox="0 0 18 15">
-          <path fill="#424242" d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.304,0,1.484l0,0C0,0.665,0.665,0,1.484,0 h15.031C17.335,0,18,0.665,18,1.484L18,1.484z"/>
-          <path fill="#424242" d="M18,7.516C18,8.335,17.335,9,16.516,9H1.484C0.665,9,0,8.335,0,7.516l0,0c0-0.82,0.665-1.484,1.484-1.484 h15.031C17.335,6.031,18,6.696,18,7.516L18,7.516z"/>
-          <path fill="#424242" d="M18,13.516C18,14.335,17.335,15,16.516,15H1.484C0.665,15,0,14.335,0,13.516l0,0 c0-0.82,0.665-1.484,1.484-1.484h15.031C17.335,12.031,18,12.696,18,13.516L18,13.516z"/>
+          <path fill="#3fb950" d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.304,0,1.484l0,0C0,0.665,0.665,0,1.484,0 h15.031C17.335,0,18,0.665,18,1.484L18,1.484z"/>
+          <path fill="#3fb950" d="M18,7.516C18,8.335,17.335,9,16.516,9H1.484C0.665,9,0,8.335,0,7.516l0,0c0-0.82,0.665-1.484,1.484-1.484 h15.031C17.335,6.031,18,6.696,18,7.516L18,7.516z"/>
+          <path fill="#3fb950" d="M18,13.516C18,14.335,17.335,15,16.516,15H1.484C0.665,15,0,14.335,0,13.516l0,0 c0-0.82,0.665-1.484,1.484-1.484h15.031C17.335,12.031,18,12.696,18,13.516L18,13.516z"/>
         </svg>
       </a>
 
       <div class="trigger">
         {% for page in site.pages %}
           {% if page.title %}
-          <a class="page-link" href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a>
+          <a class="page-link" href="{{ page.url | prepend: site.baseurl }}">./{{ page.title | downcase }}</a>
           {% endif %}
         {% endfor %}
       </div>
     </nav>
-
   </div>
-
 </header>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,6 +14,7 @@
     </div>
 
     {% include footer.html %}
+    {% include cookie-consent.html %}
 
   </body>
 

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -1,6 +1,3 @@
-/**
- * Reset some basic elements
- */
 body, h1, h2, h3, h4, h5, h6,
 p, blockquote, pre, hr,
 dl, dd, ol, ul, figure {
@@ -8,11 +5,6 @@ dl, dd, ol, ul, figure {
     padding: 0;
 }
 
-
-
-/**
- * Basic styling
- */
 body {
     font-family: $base-font-family;
     font-size: $base-font-size;
@@ -23,11 +15,6 @@ body {
     -webkit-text-size-adjust: 100%;
 }
 
-
-
-/**
- * Set `margin-bottom` to maintain vertical rhythm
- */
 h1, h2, h3, h4, h5, h6,
 p, blockquote, pre,
 ul, ol, dl, figure,
@@ -35,21 +22,11 @@ ul, ol, dl, figure,
     margin-bottom: $spacing-unit / 2;
 }
 
-
-
-/**
- * Images
- */
 img {
     max-width: 100%;
     vertical-align: middle;
 }
 
-
-
-/**
- * Figures
- */
 figure > img {
     display: block;
 }
@@ -58,11 +35,6 @@ figcaption {
     font-size: $small-font-size;
 }
 
-
-
-/**
- * Lists
- */
 ul, ol {
     margin-left: $spacing-unit;
 }
@@ -74,88 +46,69 @@ li {
     }
 }
 
-
-
-/**
- * Headings
- */
 h1, h2, h3, h4, h5, h6 {
-    font-weight: 300;
+    font-weight: 400;
+    color: $grey-color-dark;
 }
 
-
-
-/**
- * Links
- */
 a {
     color: $brand-color;
     text-decoration: none;
 
     &:visited {
-        color: darken($brand-color, 15%);
+        color: darken($brand-color, 10%);
     }
 
     &:hover {
-        color: $text-color;
-        text-decoration: underline;
+        color: $green-color;
+        text-decoration: none;
     }
 }
 
-
-
-/**
- * Blockquotes
- */
 blockquote {
     color: $grey-color;
-    border-left: 4px solid $grey-color-light;
+    border-left: 3px solid $green-color;
     padding-left: $spacing-unit / 2;
-    font-size: 18px;
-    letter-spacing: -1px;
-    font-style: italic;
+    font-size: $base-font-size;
+    font-style: normal;
 
     > :last-child {
         margin-bottom: 0;
     }
 }
 
-
-
-/**
- * Code formatting
- */
-pre,
-code {
-    font-size: 15px;
+pre, code {
+    font-family: $base-font-family;
+    font-size: 14px;
+    background-color: $code-bg;
     border: 1px solid $grey-color-light;
     border-radius: 3px;
-    background-color: #eef;
+    color: $text-color;
 }
 
 code {
-    padding: 1px 5px;
+    padding: 2px 6px;
 }
 
 pre {
-    padding: 8px 12px;
-    overflow-x: scroll;
+    padding: 12px 16px;
+    overflow-x: auto;
 
     > code {
         border: 0;
-        padding-right: 0;
-        padding-left: 0;
+        padding: 0;
+        background: transparent;
     }
 }
 
+hr {
+    border: none;
+    border-top: 1px solid $grey-color-light;
+    margin: $spacing-unit 0;
+}
 
-
-/**
- * Wrapper
- */
 .wrapper {
-    max-width: -webkit-calc(#{$content-width} - (#{$spacing-unit} * 2));
-    max-width:         calc(#{$content-width} - (#{$spacing-unit} * 2));
+    max-width: calc(#{$content-width} - (#{$spacing-unit} * 2));
     margin-right: auto;
     margin-left: auto;
     padding-right: $spacing-unit;
@@ -163,20 +116,13 @@ pre {
     @extend %clearfix;
 
     @include media-query($on-laptop) {
-        max-width: -webkit-calc(#{$content-width} - (#{$spacing-unit}));
-        max-width:         calc(#{$content-width} - (#{$spacing-unit}));
+        max-width: calc(#{$content-width} - (#{$spacing-unit}));
         padding-right: $spacing-unit / 2;
         padding-left: $spacing-unit / 2;
     }
 }
 
-
-
-/**
- * Clearfix
- */
 %clearfix {
-
     &:after {
         content: "";
         display: table;
@@ -184,21 +130,13 @@ pre {
     }
 }
 
+.icon > svg {
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    vertical-align: middle;
 
-
-/**
- * Icons
- */
-.icon {
-
-    > svg {
-        display: inline-block;
-        width: 16px;
-        height: 16px;
-        vertical-align: middle;
-
-        path {
-            fill: $grey-color;
-        }
+    path {
+        fill: $grey-color;
     }
 }

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -198,6 +198,48 @@
 
 
 /**
+ * Pagination
+ */
+.pagination {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin: $spacing-unit 0;
+    padding: ($spacing-unit / 2) 0;
+    border-top: 1px solid $grey-color-light;
+    border-bottom: 1px solid $grey-color-light;
+    font-size: $small-font-size;
+}
+
+.pagination-link {
+    color: $brand-color;
+
+    &:hover { color: $green-color; }
+}
+
+.pagination-disabled {
+    color: $grey-color-light;
+    cursor: default;
+}
+
+.pagination-info {
+    color: $grey-color;
+
+    &::before { content: "["; color: $grey-color-light; }
+    &::after  { content: "]"; color: $grey-color-light; }
+}
+
+.rss-subscribe {
+    font-size: $small-font-size;
+    color: $grey-color;
+    margin-top: $spacing-unit / 2;
+
+    a { color: $grey-color; &:hover { color: $brand-color; } }
+}
+
+
+
+/**
  * Posts
  */
 .post-header {

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -2,25 +2,28 @@
  * Site header
  */
 .site-header {
-    border-top: 5px solid $grey-color-dark;
     border-bottom: 1px solid $grey-color-light;
     min-height: 56px;
-
-    // Positioning context for the mobile navigation icon
     position: relative;
+    background-color: $background-color;
 }
 
 .site-title {
-    font-size: 26px;
+    font-size: 16px;
     line-height: 56px;
-    letter-spacing: -1px;
+    letter-spacing: 0;
     margin-bottom: 0;
     float: left;
+    font-weight: 400;
 
-    &,
-    &:visited {
-        color: $grey-color-dark;
-    }
+    .prompt-user  { color: $green-color; }
+    .prompt-at    { color: $grey-color; }
+    .prompt-host  { color: $brand-color; }
+    .prompt-sep   { color: $grey-color; }
+    .prompt-path  { color: $brand-color; }
+    .prompt-dollar { color: $green-color; }
+
+    &:hover { text-decoration: none; }
 }
 
 .site-nav {
@@ -32,23 +35,29 @@
     }
 
     .page-link {
-        color: $text-color;
+        color: $grey-color;
+        font-size: 13px;
         line-height: $base-line-height;
+        transition: color 0.15s;
 
-        // Gaps between nav items, but not on the first one
         &:not(:first-child) {
             margin-left: 20px;
+        }
+
+        &:hover {
+            color: $green-color;
         }
     }
 
     @include media-query($on-palm) {
         position: absolute;
         top: 9px;
-        right: 30px;
-        background-color: $background-color;
+        right: $spacing-unit / 2;
+        background-color: $code-bg;
         border: 1px solid $grey-color-light;
-        border-radius: 5px;
+        border-radius: 3px;
         text-align: right;
+        z-index: 10;
 
         .menu-icon {
             display: block;
@@ -62,10 +71,7 @@
             > svg {
                 width: 18px;
                 height: 15px;
-
-                path {
-                    fill: $grey-color-dark;
-                }
+                path { fill: $green-color; }
             }
         }
 
@@ -81,7 +87,9 @@
 
         .page-link {
             display: block;
-            padding: 5px 10px;
+            padding: 5px 12px;
+
+            &:not(:first-child) { margin-left: 0; }
         }
     }
 }
@@ -93,66 +101,35 @@
  */
 .site-footer {
     border-top: 1px solid $grey-color-light;
-    padding: $spacing-unit 0;
+    padding: $spacing-unit / 2 0;
+    margin-top: $spacing-unit * 2;
 }
 
-.footer-heading {
-    font-size: 18px;
-    margin-bottom: $spacing-unit / 2;
-}
-
-.contact-list,
-.social-media-list {
-    list-style: none;
-    margin-left: 0;
-}
-
-.footer-col-wrapper {
-    font-size: 15px;
+.footer-inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-size: $small-font-size;
     color: $grey-color;
-    margin-left: -$spacing-unit / 2;
-    @extend %clearfix;
-}
 
-.footer-col {
-    float: left;
-    margin-bottom: $spacing-unit / 2;
-    padding-left: $spacing-unit / 2;
-}
-
-.footer-col-1 {
-    width: -webkit-calc(35% - (#{$spacing-unit} / 2));
-    width:         calc(35% - (#{$spacing-unit} / 2));
-}
-
-.footer-col-2 {
-    width: -webkit-calc(20% - (#{$spacing-unit} / 2));
-    width:         calc(20% - (#{$spacing-unit} / 2));
-}
-
-.footer-col-3 {
-    width: -webkit-calc(45% - (#{$spacing-unit} / 2));
-    width:         calc(45% - (#{$spacing-unit} / 2));
-}
-
-@include media-query($on-laptop) {
-    .footer-col-1,
-    .footer-col-2 {
-        width: -webkit-calc(50% - (#{$spacing-unit} / 2));
-        width:         calc(50% - (#{$spacing-unit} / 2));
-    }
-
-    .footer-col-3 {
-        width: -webkit-calc(100% - (#{$spacing-unit} / 2));
-        width:         calc(100% - (#{$spacing-unit} / 2));
+    @include media-query($on-palm) {
+        flex-direction: column;
+        gap: 8px;
+        text-align: center;
     }
 }
 
-@include media-query($on-palm) {
-    .footer-col {
-        float: none;
-        width: -webkit-calc(100% - (#{$spacing-unit} / 2));
-        width:         calc(100% - (#{$spacing-unit} / 2));
+.footer-prompt {
+    .prompt-dollar { color: $green-color; }
+}
+
+.footer-links {
+    a {
+        color: $grey-color;
+        margin-left: 16px;
+
+        &:first-child { margin-left: 0; }
+        &:hover { color: $brand-color; }
     }
 }
 
@@ -163,10 +140,18 @@
  */
 .page-content {
     padding: $spacing-unit 0;
+    min-height: calc(100vh - 120px);
 }
 
 .page-heading {
-    font-size: 20px;
+    font-size: 14px;
+    color: $grey-color;
+    margin-bottom: $spacing-unit;
+
+    &::before {
+        content: "# ";
+        color: $green-color;
+    }
 }
 
 .post-list {
@@ -175,17 +160,39 @@
 
     > li {
         margin-bottom: $spacing-unit;
+        padding-bottom: $spacing-unit;
+        border-bottom: 1px solid $grey-color-light;
+
+        &:last-child {
+            border-bottom: none;
+        }
     }
 }
 
 .post-meta {
     font-size: $small-font-size;
     color: $grey-color;
+
+    &::before {
+        content: "# ";
+        color: $grey-color-light;
+    }
 }
 
 .post-link {
     display: block;
-    font-size: 24px;
+    font-size: 18px;
+    color: $text-color;
+    margin-top: 4px;
+
+    &:hover {
+        color: $brand-color;
+    }
+
+    &::before {
+        content: "> ";
+        color: $green-color;
+    }
 }
 
 
@@ -195,15 +202,18 @@
  */
 .post-header {
     margin-bottom: $spacing-unit;
+    padding-bottom: $spacing-unit / 2;
+    border-bottom: 1px solid $grey-color-light;
 }
 
 .post-title {
-    font-size: 42px;
-    letter-spacing: -1px;
-    line-height: 1;
+    font-size: 28px;
+    letter-spacing: 0;
+    line-height: 1.3;
+    color: $text-color;
 
     @include media-query($on-laptop) {
-        font-size: 36px;
+        font-size: 24px;
     }
 }
 
@@ -211,26 +221,30 @@
     margin-bottom: $spacing-unit;
 
     h2 {
-        font-size: 32px;
+        font-size: 22px;
+        margin-top: $spacing-unit;
+        color: $green-color;
 
-        @include media-query($on-laptop) {
-            font-size: 28px;
-        }
+        &::before { content: "## "; color: $grey-color-light; }
+
+        @include media-query($on-laptop) { font-size: 20px; }
     }
 
     h3 {
-        font-size: 26px;
+        font-size: 18px;
+        margin-top: $spacing-unit;
+        color: $grey-color-dark;
 
-        @include media-query($on-laptop) {
-            font-size: 22px;
-        }
+        &::before { content: "### "; color: $grey-color-light; }
+
+        @include media-query($on-laptop) { font-size: 16px; }
     }
 
     h4 {
-        font-size: 20px;
+        font-size: 15px;
+        margin-top: $spacing-unit / 2;
+        color: $grey-color;
 
-        @include media-query($on-laptop) {
-            font-size: 18px;
-        }
+        @include media-query($on-laptop) { font-size: 14px; }
     }
 }

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -198,6 +198,67 @@
 
 
 /**
+ * Cookie consent banner
+ */
+.cookie-banner {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background-color: $code-bg;
+    border-top: 1px solid $grey-color-light;
+    padding: 12px $spacing-unit;
+    z-index: 100;
+    opacity: 1;
+    transition: opacity 0.3s ease;
+}
+
+.cookie-inner {
+    max-width: calc(#{$content-width} - (#{$spacing-unit} * 2));
+    margin: 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: $spacing-unit;
+    font-size: $small-font-size;
+
+    @include media-query($on-palm) {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 10px;
+    }
+}
+
+.cookie-msg {
+    color: $grey-color;
+    line-height: 1.5;
+
+    .cookie-prompt { color: $green-color; margin-right: 4px; }
+
+    a { color: $grey-color; text-decoration: underline; &:hover { color: $brand-color; } }
+}
+
+.cookie-actions {
+    display: flex;
+    gap: 10px;
+    flex-shrink: 0;
+}
+
+.cookie-btn {
+    font-family: $base-font-family;
+    font-size: $small-font-size;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+
+    &.cookie-accept { color: $green-color; &:hover { color: lighten($green-color, 15%); } }
+    &.cookie-decline { color: $grey-color; &:hover { color: $text-color; } }
+}
+
+
+
+/**
  * Pagination
  */
 .pagination {

--- a/_sass/_syntax-highlighting.scss
+++ b/_sass/_syntax-highlighting.scss
@@ -1,67 +1,64 @@
-/**
- * Syntax highlighting styles
- */
 .highlight {
-    background: #fff;
+    background: $code-bg;
+    border: 1px solid $grey-color-light;
+    border-radius: 3px;
     @extend %vertical-rhythm;
 
-    .c     { color: #998; font-style: italic } // Comment
-    .err   { color: #a61717; background-color: #e3d2d2 } // Error
-    .k     { font-weight: bold } // Keyword
-    .o     { font-weight: bold } // Operator
-    .cm    { color: #998; font-style: italic } // Comment.Multiline
-    .cp    { color: #999; font-weight: bold } // Comment.Preproc
-    .c1    { color: #998; font-style: italic } // Comment.Single
-    .cs    { color: #999; font-weight: bold; font-style: italic } // Comment.Special
-    .gd    { color: #000; background-color: #fdd } // Generic.Deleted
-    .gd .x { color: #000; background-color: #faa } // Generic.Deleted.Specific
-    .ge    { font-style: italic } // Generic.Emph
-    .gr    { color: #a00 } // Generic.Error
-    .gh    { color: #999 } // Generic.Heading
-    .gi    { color: #000; background-color: #dfd } // Generic.Inserted
-    .gi .x { color: #000; background-color: #afa } // Generic.Inserted.Specific
-    .go    { color: #888 } // Generic.Output
-    .gp    { color: #555 } // Generic.Prompt
-    .gs    { font-weight: bold } // Generic.Strong
-    .gu    { color: #aaa } // Generic.Subheading
-    .gt    { color: #a00 } // Generic.Traceback
-    .kc    { font-weight: bold } // Keyword.Constant
-    .kd    { font-weight: bold } // Keyword.Declaration
-    .kp    { font-weight: bold } // Keyword.Pseudo
-    .kr    { font-weight: bold } // Keyword.Reserved
-    .kt    { color: #458; font-weight: bold } // Keyword.Type
-    .m     { color: #099 } // Literal.Number
-    .s     { color: #d14 } // Literal.String
-    .na    { color: #008080 } // Name.Attribute
-    .nb    { color: #0086B3 } // Name.Builtin
-    .nc    { color: #458; font-weight: bold } // Name.Class
-    .no    { color: #008080 } // Name.Constant
-    .ni    { color: #800080 } // Name.Entity
-    .ne    { color: #900; font-weight: bold } // Name.Exception
-    .nf    { color: #900; font-weight: bold } // Name.Function
-    .nn    { color: #555 } // Name.Namespace
-    .nt    { color: #000080 } // Name.Tag
-    .nv    { color: #008080 } // Name.Variable
-    .ow    { font-weight: bold } // Operator.Word
-    .w     { color: #bbb } // Text.Whitespace
-    .mf    { color: #099 } // Literal.Number.Float
-    .mh    { color: #099 } // Literal.Number.Hex
-    .mi    { color: #099 } // Literal.Number.Integer
-    .mo    { color: #099 } // Literal.Number.Oct
-    .sb    { color: #d14 } // Literal.String.Backtick
-    .sc    { color: #d14 } // Literal.String.Char
-    .sd    { color: #d14 } // Literal.String.Doc
-    .s2    { color: #d14 } // Literal.String.Double
-    .se    { color: #d14 } // Literal.String.Escape
-    .sh    { color: #d14 } // Literal.String.Heredoc
-    .si    { color: #d14 } // Literal.String.Interpol
-    .sx    { color: #d14 } // Literal.String.Other
-    .sr    { color: #009926 } // Literal.String.Regex
-    .s1    { color: #d14 } // Literal.String.Single
-    .ss    { color: #990073 } // Literal.String.Symbol
-    .bp    { color: #999 } // Name.Builtin.Pseudo
-    .vc    { color: #008080 } // Name.Variable.Class
-    .vg    { color: #008080 } // Name.Variable.Global
-    .vi    { color: #008080 } // Name.Variable.Instance
-    .il    { color: #099 } // Literal.Number.Integer.Long
+    .c     { color: #8b949e; font-style: italic }   // Comment
+    .err   { color: #f85149; background-color: transparent }  // Error
+    .k     { color: #ff7b72 }                        // Keyword
+    .o     { color: #e6edf3 }                        // Operator
+    .cm    { color: #8b949e; font-style: italic }    // Comment.Multiline
+    .cp    { color: #8b949e }                        // Comment.Preproc
+    .c1    { color: #8b949e; font-style: italic }    // Comment.Single
+    .cs    { color: #8b949e; font-style: italic }    // Comment.Special
+    .gd    { color: #f85149 }                        // Generic.Deleted
+    .ge    { font-style: italic }                    // Generic.Emph
+    .gr    { color: #f85149 }                        // Generic.Error
+    .gh    { color: #79c0ff; font-weight: bold }     // Generic.Heading
+    .gi    { color: #3fb950 }                        // Generic.Inserted
+    .go    { color: #8b949e }                        // Generic.Output
+    .gp    { color: #3fb950; font-weight: bold }     // Generic.Prompt
+    .gs    { font-weight: bold }                     // Generic.Strong
+    .gu    { color: #79c0ff }                        // Generic.Subheading
+    .gt    { color: #f85149 }                        // Generic.Traceback
+    .kc    { color: #79c0ff }                        // Keyword.Constant
+    .kd    { color: #ff7b72 }                        // Keyword.Declaration
+    .kp    { color: #ff7b72 }                        // Keyword.Pseudo
+    .kr    { color: #ff7b72 }                        // Keyword.Reserved
+    .kt    { color: #79c0ff }                        // Keyword.Type
+    .m     { color: #79c0ff }                        // Literal.Number
+    .s     { color: #a5d6ff }                        // Literal.String
+    .na    { color: #79c0ff }                        // Name.Attribute
+    .nb    { color: #e6edf3 }                        // Name.Builtin
+    .nc    { color: #f0883e }                        // Name.Class
+    .no    { color: #79c0ff }                        // Name.Constant
+    .ni    { color: #e6edf3 }                        // Name.Entity
+    .ne    { color: #f85149; font-weight: bold }     // Name.Exception
+    .nf    { color: #d2a8ff }                        // Name.Function
+    .nn    { color: #e6edf3 }                        // Name.Namespace
+    .nt    { color: #7ee787 }                        // Name.Tag
+    .nv    { color: #e6edf3 }                        // Name.Variable
+    .ow    { color: #ff7b72 }                        // Operator.Word
+    .w     { color: #8b949e }                        // Text.Whitespace
+    .mf    { color: #79c0ff }                        // Literal.Number.Float
+    .mh    { color: #79c0ff }                        // Literal.Number.Hex
+    .mi    { color: #79c0ff }                        // Literal.Number.Integer
+    .mo    { color: #79c0ff }                        // Literal.Number.Oct
+    .sb    { color: #a5d6ff }                        // Literal.String.Backtick
+    .sc    { color: #a5d6ff }                        // Literal.String.Char
+    .sd    { color: #a5d6ff }                        // Literal.String.Doc
+    .s2    { color: #a5d6ff }                        // Literal.String.Double
+    .se    { color: #a5d6ff }                        // Literal.String.Escape
+    .sh    { color: #a5d6ff }                        // Literal.String.Heredoc
+    .si    { color: #a5d6ff }                        // Literal.String.Interpol
+    .sx    { color: #a5d6ff }                        // Literal.String.Other
+    .sr    { color: #7ee787 }                        // Literal.String.Regex
+    .s1    { color: #a5d6ff }                        // Literal.String.Single
+    .ss    { color: #a5d6ff }                        // Literal.String.Symbol
+    .bp    { color: #8b949e }                        // Name.Builtin.Pseudo
+    .vc    { color: #e6edf3 }                        // Name.Variable.Class
+    .vg    { color: #e6edf3 }                        // Name.Variable.Global
+    .vi    { color: #e6edf3 }                        // Name.Variable.Instance
+    .il    { color: #79c0ff }                        // Literal.Number.Integer.Long
 }

--- a/css/main.scss
+++ b/css/main.scss
@@ -3,7 +3,7 @@
 ---
 @charset "utf-8";
 
-$base-font-family: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
+$base-font-family: 'Fira Code', 'Courier New', monospace;
 $base-font-size:   15px;
 $small-font-size:  $base-font-size * 0.875;
 $base-line-height: 1.7;

--- a/css/main.scss
+++ b/css/main.scss
@@ -3,48 +3,36 @@
 ---
 @charset "utf-8";
 
-
-
-// Our variables
-$base-font-family: 'Open Sans', sans-serif;
-$base-font-size:   16px;
+$base-font-family: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
+$base-font-size:   15px;
 $small-font-size:  $base-font-size * 0.875;
-$base-line-height: 1.5;
+$base-line-height: 1.7;
 
 $spacing-unit:     30px;
 
-$text-color:       #111;
-$background-color: #fdfdfd;
-$brand-color:      #2a7ae2;
+$text-color:       #e6edf3;
+$background-color: #0d1117;
+$brand-color:      #58a6ff;
 
-$grey-color:       #828282;
-$grey-color-light: lighten($grey-color, 40%);
-$grey-color-dark:  darken($grey-color, 25%);
+$green-color:      #3fb950;
 
-// Width of the content area
+$grey-color:       #8b949e;
+$grey-color-light: #30363d;
+$grey-color-dark:  #c9d1d9;
+
+$code-bg:          #161b22;
+
 $content-width:    800px;
 
 $on-palm:          600px;
 $on-laptop:        800px;
 
-
-
-// Using media queries with like this:
-// @include media-query($on-palm) {
-//     .wrapper {
-//         padding-right: $spacing-unit / 2;
-//         padding-left: $spacing-unit / 2;
-//     }
-// }
 @mixin media-query($device) {
     @media screen and (max-width: $device) {
         @content;
     }
 }
 
-
-
-// Import partials from `sass_dir` (defaults to `_sass`)
 @import
         "base",
         "layout",

--- a/index.html
+++ b/index.html
@@ -7,16 +7,35 @@ layout: default
   <h1 class="page-heading">Posts</h1>
 
   <ul class="post-list">
-    {% for post in site.posts %}
+    {% for post in paginator.posts %}
       <li>
         <span class="post-meta">{{ post.date | date: "%b %-d, %Y" }}</span>
-
         <h2>
           <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
         </h2>
       </li>
     {% endfor %}
   </ul>
+
+  {% if paginator.total_pages > 1 %}
+  <nav class="pagination">
+    {% if paginator.previous_page %}
+      <a class="pagination-link" href="{{ paginator.previous_page_path | prepend: site.baseurl }}">&larr; newer</a>
+    {% else %}
+      <span class="pagination-link pagination-disabled">&larr; newer</span>
+    {% endif %}
+
+    <span class="pagination-info">
+      {{ paginator.page }} / {{ paginator.total_pages }}
+    </span>
+
+    {% if paginator.next_page %}
+      <a class="pagination-link" href="{{ paginator.next_page_path | prepend: site.baseurl }}">older &rarr;</a>
+    {% else %}
+      <span class="pagination-link pagination-disabled">older &rarr;</span>
+    {% endif %}
+  </nav>
+  {% endif %}
 
   <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | prepend: site.baseurl }}">via RSS</a></p>
 


### PR DESCRIPTION
## Co się zmieniło

### Motyw — terminal dark theme
- Usunięto `remote_theme: merlot` — pełna kontrola przez lokalne pliki
- Czcionka **Fira Code** (SIL OFL, Mozilla) zamiast Open Sans
- Paleta: tło `#0d1117`, tekst `#e6edf3`, akcenty zielony `#3fb950` / niebieski `#58a6ff`
- Header w stylu promptu: `biscoitinho@github:~ $` z linkami jako `./about`
- Footer: `$ exit 0` z linkami do GitHub i email
- Nagłówki h2/h3 w postach z prefiksem `##` / `###`
- Dark syntax highlighting inspirowany GitHub Dark

### Paginacja
- Plugin `jekyll-paginate` — 10 postów na stronę (41 postów → 5 stron)
- Nawigacja: `← newer  [2 / 5]  older →`

### Banner cookies
- Pasek na dole ekranu: `$ cookies.sh: ta strona używa plików cookie...`
- Przyciski `[ akceptuję ]` / `[ odrzucam ]`
- Decyzja zapisywana w `localStorage` — banner nie wraca po odświeżeniu
- Fade out 300ms po kliknięciu

## Test plan
- [ ] Strona główna wyświetla 10 postów i paginację
- [ ] Nawigacja między stronami działa poprawnie
- [ ] Banner cookies pojawia się przy pierwszej wizycie
- [ ] Banner nie wraca po odświeżeniu (po kliknięciu)
- [ ] Widok mobilny — banner i nawigacja nie nakładają się
- [ ] Posty indywidualne wyświetlają się z nowym motywem

---
_Generated by [Claude Code](https://claude.ai/code/session_01E6qBXyy7tBeiXjLmvqDmwA)_