### PR TITLE
Paginacja i banner cookies

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,8 +4,10 @@ email: matgrotha@gmail.com
 description: > # this means to ignore newlines until "baseurl:"
   developer, ruby, DIY, linux, martial arts
 remote_theme: pages-themes/merlot@v0.2.0
-plugins:
-- jekyll-remote-theme
+
+paginate: 10
+paginate_path: "/page:num/"
+
 baseurl: "" # the subpath of your site, e.g. /blog/
 url: "https://biscoitinho.github.io"
 twitter_username:
@@ -13,3 +15,6 @@ github_username:  biscoitinho
 
 # Build settings
 markdown: kramdown
+plugins:
+  - jekyll-remote-theme
+  - jekyll-paginate

--- a/_includes/cookie-consent.html
+++ b/_includes/cookie-consent.html
@@ -2,12 +2,12 @@
   <div class="cookie-inner">
     <span class="cookie-msg">
       <span class="cookie-prompt">$</span> cookies.sh:
-      ta strona używa plików cookie do analizy ruchu i podstawowych funkcji.
+      this site uses cookies for analytics and basic functionality.
       <a href="https://policies.google.com/privacy" target="_blank" rel="noopener">więcej info</a>
     </span>
     <div class="cookie-actions">
-      <button class="cookie-btn cookie-accept" onclick="cookieConsent(true)">[ akceptuję ]</button>
-      <button class="cookie-btn cookie-decline" onclick="cookieConsent(false)">[ odrzucam ]</button>
+      <button class="cookie-btn cookie-accept" onclick="cookieConsent(true)">[ accept ]</button>
+      <button class="cookie-btn cookie-decline" onclick="cookieConsent(false)">[ decline ]</button>
     </div>
   </div>
 </div>

--- a/_includes/cookie-consent.html
+++ b/_includes/cookie-consent.html
@@ -1,0 +1,28 @@
+<div class="cookie-banner" id="cookieBanner">
+  <div class="cookie-inner">
+    <span class="cookie-msg">
+      <span class="cookie-prompt">$</span> cookies.sh:
+      ta strona używa plików cookie do analizy ruchu i podstawowych funkcji.
+      <a href="https://policies.google.com/privacy" target="_blank" rel="noopener">więcej info</a>
+    </span>
+    <div class="cookie-actions">
+      <button class="cookie-btn cookie-accept" onclick="cookieConsent(true)">[ akceptuję ]</button>
+      <button class="cookie-btn cookie-decline" onclick="cookieConsent(false)">[ odrzucam ]</button>
+    </div>
+  </div>
+</div>
+
+<script>
+  (function() {
+    if (localStorage.getItem('cookie-consent') !== null) {
+      document.getElementById('cookieBanner').style.display = 'none';
+    }
+  })();
+
+  function cookieConsent(accepted) {
+    localStorage.setItem('cookie-consent', accepted ? 'accepted' : 'declined');
+    var banner = document.getElementById('cookieBanner');
+    banner.style.opacity = '0';
+    setTimeout(function() { banner.style.display = 'none'; }, 300);
+  }
+</script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,6 +14,7 @@
     </div>
 
     {% include footer.html %}
+    {% include cookie-consent.html %}
 
   </body>
 

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -198,7 +198,7 @@
     bottom: 0;
     left: 0;
     right: 0;
-    background-color: $code-bg;
+    background-color: $background-color;
     border-top: 1px solid $grey-color-light;
     padding: 12px $spacing-unit;
     z-index: 100;
@@ -226,7 +226,7 @@
     color: $grey-color;
     line-height: 1.5;
 
-    .cookie-prompt { color: $green-color; margin-right: 4px; }
+    .cookie-prompt { color: $brand-color; margin-right: 4px; }
 
     a { color: $grey-color; text-decoration: underline; &:hover { color: $brand-color; } }
 }
@@ -245,7 +245,7 @@
     cursor: pointer;
     padding: 0;
 
-    &.cookie-accept { color: $green-color; &:hover { color: lighten($green-color, 15%); } }
+    &.cookie-accept { color: $brand-color; &:hover { color: lighten($brand-color, 15%); } }
     &.cookie-decline { color: $grey-color; &:hover { color: $text-color; } }
 }
 

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -191,6 +191,67 @@
 
 
 /**
+ * Cookie consent banner
+ */
+.cookie-banner {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background-color: $code-bg;
+    border-top: 1px solid $grey-color-light;
+    padding: 12px $spacing-unit;
+    z-index: 100;
+    opacity: 1;
+    transition: opacity 0.3s ease;
+}
+
+.cookie-inner {
+    max-width: calc(#{$content-width} - (#{$spacing-unit} * 2));
+    margin: 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: $spacing-unit;
+    font-size: $small-font-size;
+
+    @include media-query($on-palm) {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 10px;
+    }
+}
+
+.cookie-msg {
+    color: $grey-color;
+    line-height: 1.5;
+
+    .cookie-prompt { color: $green-color; margin-right: 4px; }
+
+    a { color: $grey-color; text-decoration: underline; &:hover { color: $brand-color; } }
+}
+
+.cookie-actions {
+    display: flex;
+    gap: 10px;
+    flex-shrink: 0;
+}
+
+.cookie-btn {
+    font-family: $base-font-family;
+    font-size: $small-font-size;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+
+    &.cookie-accept { color: $green-color; &:hover { color: lighten($green-color, 15%); } }
+    &.cookie-decline { color: $grey-color; &:hover { color: $text-color; } }
+}
+
+
+
+/**
  * Pagination
  */
 .pagination {

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -191,6 +191,48 @@
 
 
 /**
+ * Pagination
+ */
+.pagination {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin: $spacing-unit 0;
+    padding: ($spacing-unit / 2) 0;
+    border-top: 1px solid $grey-color-light;
+    border-bottom: 1px solid $grey-color-light;
+    font-size: $small-font-size;
+}
+
+.pagination-link {
+    color: $brand-color;
+
+    &:hover { color: darken($brand-color, 10%); }
+}
+
+.pagination-disabled {
+    color: $grey-color-light;
+    cursor: default;
+}
+
+.pagination-info {
+    color: $grey-color;
+
+    &::before { content: "["; color: $grey-color-light; }
+    &::after  { content: "]"; color: $grey-color-light; }
+}
+
+.rss-subscribe {
+    font-size: $small-font-size;
+    color: $grey-color;
+    margin-top: $spacing-unit / 2;
+
+    a { color: $grey-color; &:hover { color: $brand-color; } }
+}
+
+
+
+/**
  * Posts
  */
 .post-header {

--- a/index.html
+++ b/index.html
@@ -7,16 +7,35 @@ layout: default
   <h1 class="page-heading">Posts</h1>
 
   <ul class="post-list">
-    {% for post in site.posts %}
+    {% for post in paginator.posts %}
       <li>
         <span class="post-meta">{{ post.date | date: "%b %-d, %Y" }}</span>
-
         <h2>
           <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
         </h2>
       </li>
     {% endfor %}
   </ul>
+
+  {% if paginator.total_pages > 1 %}
+  <nav class="pagination">
+    {% if paginator.previous_page %}
+      <a class="pagination-link" href="{{ paginator.previous_page_path | prepend: site.baseurl }}">&larr; newer</a>
+    {% else %}
+      <span class="pagination-link pagination-disabled">&larr; newer</span>
+    {% endif %}
+
+    <span class="pagination-info">
+      {{ paginator.page }} / {{ paginator.total_pages }}
+    </span>
+
+    {% if paginator.next_page %}
+      <a class="pagination-link" href="{{ paginator.next_page_path | prepend: site.baseurl }}">older &rarr;</a>
+    {% else %}
+      <span class="pagination-link pagination-disabled">older &rarr;</span>
+    {% endif %}
+  </nav>
+  {% endif %}
 
   <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | prepend: site.baseurl }}">via RSS</a></p>
 


### PR DESCRIPTION
## Co się zmieniło

### Paginacja
- Plugin `jekyll-paginate` aktywowany w `_config.yml`
- 10 postów na stronę (41 postów → 5 stron)
- Nawigacja: `← newer  [2 / 5]  older →`

### Banner cookies
- Pasek na dole ekranu: `$ cookies.sh: ta strona używa plików cookie...`
- Przyciski `[ akceptuję ]` / `[ odrzucam ]`
- Decyzja zapisywana w `localStorage` — banner nie wraca po odświeżeniu
- Fade out 300ms po kliknięciu

## Test plan
- [ ] Strona główna wyświetla 10 postów i nawigację paginacji
- [ ] Linki ← newer / older → działają poprawnie
- [ ] Banner cookies pojawia się przy pierwszej wizycie
- [ ] Po kliknięciu banner nie wraca po odświeżeniu strony
- [ ] Widok mobilny — banner i paginacja wyglądają poprawnie

---
_Generated by [Claude Code](https://claude.ai/code/session_01E6qBXyy7tBeiXjLmvqDmwA)_